### PR TITLE
Replace old PLEX TypeID with new PLEX

### DIFF
--- a/MarketScript.gs
+++ b/MarketScript.gs
@@ -19,7 +19,7 @@ var sortOrder = 1;
 function initializeGetMarketPrice()
 {
   // Test PLEX in Dodixie
-  var itemId = 29668;
+  var itemId = 44992;
   var regionId = 10000032;
   var stationId = 60011866;
   var orderType = "SELL";


### PR DESCRIPTION
I've replaced old Plex TypeID in initializeGetMarketPrice function with the new one.